### PR TITLE
chore: add template de issue para bugs, duplicações e erros

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug---duplicacao---erros.md
+++ b/.github/ISSUE_TEMPLATE/bug---duplicacao---erros.md
@@ -1,0 +1,37 @@
+---
+name: Bug | Duplicação | Erros
+about: Informe um problema de formatação, duplicação ou erro em algum conteúdo do repositório
+title: "Correção - [descrição breve do problema]"
+labels: ["bug", "collab", "duplicate"]
+assignees: []
+---
+
+💜 Obrigada por ajudar a manter o projeto **Mulheres na Tecnologia** com qualidade!  
+Use este template para relatar **problemas de formatação, duplicação de conteúdo ou erros de informação**.
+
+---
+
+### 🪲 Qual o arquivo com problema ou duplicação:
+> Indique o caminho ou nome do arquivo.  
+> _(Ex: README.md ou comunidades.md)_
+
+---
+
+### ❌ Qual bug, duplicação ou erro encontrado?
+> Descreva o problema de forma clara.  
+> Inclua o trecho ou linha afetada, se possível.
+
+---
+
+### ⚠️ Sugestão de correção
+> Explique brevemente como o problema pode ser resolvido  
+> _(Ex: remover duplicata, corrigir link, ajustar nome, revisar formatação)_
+
+---
+
+### 📝 Mais detalhes (opcional)
+> Adicione informações complementares, prints ou exemplos, se desejar.
+
+---
+
+🔍 *Contribuições como esta ajudam a manter o repositório limpo, coerente e de fácil manutenção.*


### PR DESCRIPTION
Este PR adiciona um **novo template de issue** em `.github/ISSUE_TEMPLATE/bug---duplicacao---erros.md`,  
voltado para reportar **problemas de formatação, duplicação de perfis/comunidades e erros de informação**. 💜  

Com este modelo, colaboradoras poderão abrir issues estruturadas para relatar inconsistências,  
facilitando a manutenção e a revisão colaborativa do conteúdo.  

O que foi adicionado
- Template de issue com campos para:
  - Arquivo afetado  
  - Descrição do problema  
  - Sugestão de correção  
  - Detalhes adicionais
- Labels automáticas: `bug`, `collab`, `duplicate`
- Estrutura padronizada e coerente com o tom do projeto

Checklist
- [x] Arquivo criado em `.github/ISSUE_TEMPLATE/`
- [x] Texto revisado e formatado em Markdown  
- [x] Labels configuradas corretamente  

Impacto esperado
- Melhorar a organização e triagem de issues  
- Permitir que a comunidade reporte duplicações e erros de forma clara  
- Fortalecer o cuidado com a qualidade e curadoria do conteúdo  

Observação  
> **Por favor, adicione a label `hacktoberfest-accepted` caso o PR seja aprovado**,  
> para que a contribuição seja contabilizada oficialmente no evento Hacktoberfest 2025.
